### PR TITLE
Add Q4 courses and link to Kenny's Container persistence presentation

### DIFF
--- a/accreditation/README.md
+++ b/accreditation/README.md
@@ -18,3 +18,6 @@ Here are direct links to the accreditation course videos on YouTube:
 
 ## Q4
  - [Container Data Persistence presentation](http://kendrickcoleman.com/slides/containerpersistence/#/)
+ - Intro to NoSQL
+ - Intro to Continuous Integration
+ - Container Management - Mesos

--- a/accreditation/README.md
+++ b/accreditation/README.md
@@ -10,8 +10,11 @@ Here are direct links to the accreditation course videos on YouTube:
  - [Intro to Agile Methodology](https://www.youtube.com/watch?v=78jdpP3jw4A&index=9&list=PLbssOJyyvHuWiBQAg9EFWH570timj2fxt)
  - [Modern DevOps Communication and Collaboration Tools](https://www.youtube.com/watch?v=khMbosLRuFo&index=5&list=PLbssOJyyvHuWiBQAg9EFWH570timj2fxt)
 
-##Q3
+## Q3
  - [DevOps Tools - Vagrant and Packer](https://www.youtube.com/watch?v=6-7WjA-hHvg&index=2&list=PLbssOJyyvHuWiBQAg9EFWH570timj2fxt)
  - [DevOps Tools - Cloud Foundry](https://www.youtube.com/watch?v=qr_gro2TCGU&index=6&list=PLbssOJyyvHuWiBQAg9EFWH570timj2fxt)
  - [Intro to Container Management and CoreOS](https://www.youtube.com/watch?v=-aQOGsHm_bo&index=8&list=PLbssOJyyvHuWiBQAg9EFWH570timj2fxt)
  - [Intro to Container Management and Kubernetes](https://www.youtube.com/watch?v=qCxYjq7EBHc&index=7&list=PLbssOJyyvHuWiBQAg9EFWH570timj2fxt)
+
+## Q4
+ - [Container Data Persistence presentation](http://kendrickcoleman.com/slides/containerpersistence/#/)


### PR DESCRIPTION
Instead of filling the repo with all the Reveal.JS code we're going the easy route of just adding a link to Kenny's presentation.

YouTube links will be up when they're posted.