### PR TITLE
Updating link to Mesos image

### DIFF
--- a/accreditation/container-management-mesos.md
+++ b/accreditation/container-management-mesos.md
@@ -41,7 +41,7 @@ Web UI for viewing cluster state
 
 ---
 
-![fit](images/mesos.png)
+![fit](https://raw.githubusercontent.com/emccode/training/master/accreditation/images/mesos.png)
 
 ---
 
@@ -121,7 +121,7 @@ http://mesos.apache.org/documentation/latest/powered-by-mesos/
 
 https://github.com/mesosphere/playa-mesos
 
-https://github.com/everpeace/vagrant-mesos
+https://github.com/jonasrosland/vagrant-mesos
 
 ---
 


### PR DESCRIPTION
Updating link to Mesos image to work with Remarkise:

https://gnab.github.io/remark/remarkise?url=https%3A%2F%2Fraw.githubusercontent.com%2Femccode%2Ftraining%2Fmaster%2Faccreditation%2Fcontainer-management-mesos.md

Also updating the link to our example vagrant-mesos repo.

Signed-off-by: jonas.rosland@gmail.com