### PR TITLE
A couple fixes found when going through lab

### DIFF
--- a/docker-workshops/docker-storage-networking/lab4-container-persistence/README.md
+++ b/docker-workshops/docker-storage-networking/lab4-container-persistence/README.md
@@ -137,7 +137,7 @@ $ docker run -ti --name temp --volume-driver=rexray -v <volName>:/test busybox
 
 Once we are in our container, let's validate that the external volume is mounted as expected.  The following path shows the `/dev/xvdb` volume mounted to `/test`.
 ```
-/ # df /student001
+/ # df /test
 Filesystem           1K-blocks      Used Available Use% Mounted on
 /dev/xvdb             16382888     45036  15482608   0% /test
 ```
@@ -204,7 +204,7 @@ $ docker ps
 Attach to the host with `$ docker attach hosta` and verify that the volume is mounted as expected.  Notice how `/dev/xvdb` is mounted to `/test`
 
 ```
-/ # df /student001a/
+/ # df /test
 Filesystem           1K-blocks      Used Available Use% Mounted on
 /dev/xvdb             10190136     23028   9626436   0% /test
 ```

--- a/docker-workshops/docker-storage-networking/prep/README.md
+++ b/docker-workshops/docker-storage-networking/prep/README.md
@@ -17,7 +17,6 @@ The `docker-machine` AWS security group should have the following ports open
 | TCP      | 7946       |
 | TCP      | 5000       |
 | TCP      | 2376       |
-| TCP      | 7946       |
 | TCP      | 2375       |
 | UDP      | 4789       |
 | TCP      | 443        |


### PR DESCRIPTION
The `df` commands were incorrect.  They were using the hostname rather than the file path.

The port list for the security group had a duplicate entry.  If you used that list to create a secgroup from scratch, you got an error code for having a duplicate rule.